### PR TITLE
Only use conda-forge as a source for packages

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,4 +23,5 @@ dependencies:
 - cvxpy=1.3.1
 - biotite=0.36.1
 - biopandas=0.4.1
+- pytorch_cluster
 name: kinodata

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ dependencies:
 - numpy=1.24.1
 - pip=22.3.1
 - python=3.10.8
-- pytorch::pytorch=1.13.1
-- pyg::pyg=2.2.0
+- pytorch=1.13.1
+- pytorch_geometric=2.2.0
 - pandas=1.5.2
 - scipy=1.10.0
 - tqdm=4.64.1


### PR DESCRIPTION
Both pytorch and pyg are on conda-forge. By installing these packages from conda-forge, you can get the GPU versions of these packages auto-magically if the environment is created on a computer with a CUDA GPU. 